### PR TITLE
fix all uses of float for money related data. A float looses precision

### DIFF
--- a/day1/src/Hotel.Bookings.Domain/Money.cs
+++ b/day1/src/Hotel.Bookings.Domain/Money.cs
@@ -3,14 +3,14 @@ using CoreLib;
 
 namespace Hotel.Bookings.Domain {
     public record Money {
-        public float  Amount   { get; internal init; }
+        public decimal  Amount   { get; internal init; }
         public string Currency { get; internal init; }
 
         static readonly string[] SupportedCurrencies = {"USD", "EUR", "GPB"};
 
         internal Money() { }
 
-        public Money(float amount, string currency) {
+        public Money(decimal amount, string currency) {
             if (!SupportedCurrencies.Contains(currency)) throw new DomainException($"Unsupported currency: {currency}");
 
             Amount   = amount;
@@ -25,6 +25,6 @@ namespace Hotel.Bookings.Domain {
             return new Money(one.Amount - another.Amount, one.Currency);
         }
 
-        public static implicit operator double(Money money) => money.Amount;
+        public static implicit operator decimal(Money money) => money.Amount;
     }
 }

--- a/day1/src/Hotel.Bookings/Application/Bookings/Commands.cs
+++ b/day1/src/Hotel.Bookings/Application/Bookings/Commands.cs
@@ -8,7 +8,7 @@ namespace Hotel.Bookings.Application.Bookings {
             string         RoomId,
             DateTimeOffset CheckInDate,
             DateTimeOffset CheckOutDate,
-            float          BookingPrice,
+            decimal        BookingPrice,
             string         Currency,
             DateTimeOffset BookingDate
         );

--- a/day1/src/Hotel.Payments/Application/CommandService.cs
+++ b/day1/src/Hotel.Payments/Application/CommandService.cs
@@ -18,6 +18,6 @@ namespace Hotel.Payments.Application {
     }
 
     public static class PaymentCommands {
-        public record RecordPayment(string PaymentId, string BookingId, float Amount, string Method, string Provider);
+        public record RecordPayment(string PaymentId, string BookingId,decimal Amount, string Method, string Provider);
     }
 }

--- a/day1/src/Hotel.Payments/Domain/Payment.cs
+++ b/day1/src/Hotel.Payments/Domain/Payment.cs
@@ -3,14 +3,14 @@ using static Hotel.Payments.Domain.PaymentEvents;
 
 namespace Hotel.Payments.Domain {
     public class Payment : Aggregate<PaymentState, PaymentId> {
-        public void ProcessPayment(PaymentId paymentId, string bookingId, float amount, string method, string provider) {
+        public void ProcessPayment(PaymentId paymentId, string bookingId, decimal amount, string method, string provider) {
             Apply(new PaymentRecorded(paymentId, bookingId, amount, method, provider));
         }
     }
 
     public record PaymentState : AggregateState<PaymentState, PaymentId> {
         public string BookingId { get; init; }
-        public float  Amount    { get; init; }
+        public decimal Amount    { get; init; }
     }
 
     public record PaymentId(string Value) : AggregateId(Value);

--- a/day1/src/Hotel.Payments/Domain/PaymentEvents.cs
+++ b/day1/src/Hotel.Payments/Domain/PaymentEvents.cs
@@ -2,7 +2,7 @@ using Eventuous;
 
 namespace Hotel.Payments.Domain {
     public static class PaymentEvents {
-        public record PaymentRecorded(string PaymentId, string BookingId, float Amount, string Method, string Provider);
+        public record PaymentRecorded(string PaymentId, string BookingId, decimal Amount, string Method, string Provider);
 
         public static void MapEvents() {
             TypeMap.AddType<PaymentRecorded>("PaymentRecorded");


### PR DESCRIPTION
…on and should never be used when you need to keep precision like with money unless you want to get into trouble. See explanation e.g. here: https://stackoverflow.com/questions/3730019/why-not-use-double-or-float-to-represent-currency